### PR TITLE
Use find_packages() to package all packages of module.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,18 @@
 django-jobvite
 ==============
 
-django-jobvite is a `Django`_ application that provides a friendly interface to 
+django-jobvite is a `Django`_ application that provides a friendly interface to
 Jobvite.
 
 .. _Django: http://www.djangoproject.com/
 
 Installation
 ------------
+Fetch django-jobvite::
 
-To use ``django_jobvite`` to ``INSTALLED_APPS`` in ``settings.py``: ::
+  pip install -e git://github.com/mozilla/django-jobvite
+
+Add ``django_jobvite`` to ``INSTALLED_APPS`` in ``settings.py``: ::
 
    INSTALLED_APPS = (
        ...
@@ -31,7 +34,7 @@ Additionally, you'll need to specify the URI to the Jobvite XML file: ::
 
 Use
 ---
-Once installed and configured, you can query jobvite positions and obtain 
+Once installed and configured, you can query jobvite positions and obtain
 results in JSON, keyed by jobvite ID. Any GET parameters will be used as
 filter parameters. Example JSON: ::
 

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,7 @@ setup(
     url='http://github.com/mozilla/django-jobvite',
     license='BSD',
     packages=find_packages(),
+    install_requires=[
+        "bleach>=1.4.1",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 import django_jobvite
 
@@ -12,5 +12,5 @@ setup(
     author_email='paul@mozillafoundation.org',
     url='http://github.com/mozilla/django-jobvite',
     license='BSD',
-    packages=['django_jobvite'],
+    packages=find_packages(),
 )


### PR DESCRIPTION
Current setup.py includes only the django_jobvite package and excludes all
the packages within the django_jobvite directory, like migrations,
management, etc. Long story short, if you install django_jobvite using
pip it doesn't work.