### PR TITLE
Jobvite urls.py backward compatibility

### DIFF
--- a/django_jobvite/urls.py
+++ b/django_jobvite/urls.py
@@ -1,6 +1,8 @@
-from django.conf.urls.defaults import patterns, url
-
-
+try:
+    from django.conf.urls import patterns, url
+except:
+    from django.conf.urls.defaults import patterns, url
+    
 urlpatterns = patterns('',
     url(r'^positions/$', 'django_jobvite.views.positions',
         name='django_jobvite_positions'),

--- a/django_jobvite/urls.py
+++ b/django_jobvite/urls.py
@@ -1,6 +1,6 @@
 try:
     from django.conf.urls import patterns, url
-except:
+except ImportError:
     from django.conf.urls.defaults import patterns, url
     
 urlpatterns = patterns('',


### PR DESCRIPTION
Since django 1.6, `django.conf.urls,defaults` has been removed !